### PR TITLE
[READY FOR REVIEW]🔒[BUG] Bug/issue 27 external secret

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,21 +10,23 @@ fast_api_logger.handlers = logger.handlers
 
 
 class Settings(BaseSettings):
-    PROJECT_NAME: str="Uptime-Kuma-API"
+    PROJECT_NAME: str = "Uptime-Kuma-API"
     BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
-    
-    ACCESS_TOKEN_EXPIRE: int = os.environ.get('ACCESS_TOKEN_EXPIRATION',60 * 24 * 8) #8 days
-    SECRET_KEY: str = secrets.token_urlsafe(32)
 
-    KUMA_SERVER: str = os.environ.get('KUMA_SERVER')
-    KUMA_USERNAME: str = os.environ.get('KUMA_USERNAME')
-    KUMA_PASSWORD: str = os.environ.get('KUMA_PASSWORD')
+    ACCESS_TOKEN_EXPIRE: int = os.environ.get(
+        "ACCESS_TOKEN_EXPIRATION", 60 * 24 * 8
+    )  # 8 days
+    SECRET_KEY: str = os.environ.get("SECRET_KEY") or secrets.token_urlsafe(32)
 
-    ADMIN_PASSWORD: str = os.environ.get('ADMIN_PASSWORD')
+    KUMA_SERVER: str = os.environ.get("KUMA_SERVER")
+    KUMA_USERNAME: str = os.environ.get("KUMA_USERNAME")
+    KUMA_PASSWORD: str = os.environ.get("KUMA_PASSWORD")
 
+    ADMIN_PASSWORD: str = os.environ.get("ADMIN_PASSWORD")
 
     class Config:
         case_sensitive = True
         env_file = ".env"
+
 
 settings = Settings()

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE: int = os.environ.get(
         "ACCESS_TOKEN_EXPIRATION", 60 * 24 * 8
     )  # 8 days
-    SECRET_KEY: str = os.environ.get("SECRET_KEY") or secrets.token_urlsafe(32)
+    SECRET_KEY: str = os.environ.get("SECRET_KEY", secrets.token_urlsafe(32))
 
     KUMA_SERVER: str = os.environ.get("KUMA_SERVER")
     KUMA_USERNAME: str = os.environ.get("KUMA_USERNAME")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - KUMA_PASSWORD=${KUMA_PASSWORD:-123test.}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin}
       # - ACCESS_TOKEN_EXPIRATION=${ACCESS_TOKEN_EXPIRATION:-1}
+      - SECRET_KEY=${SECRET_KEY:-pO8WunLtrznm2i4NfOJ25BkG4sh4kYwN1FjzZp8O6E0} #random 32bit string that's url safe.
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
# 🔒 Externalize Secret Key for Consistency Across Instances
---
## Fixes: #27 
---
## Description: 

In this pull request, I made a change to the way the `SECRET_KEY` is generated and stored. Previously, the `SECRET_KEY` was generated within the code using `secrets.token_urlsafe(32)`, which meant that every instance of the application had a different secret key. This was causing issues in a replicated setup, as every second call (in a round-robin manner) was failing due to inconsistency in secret keys between instances.

To address this issue, I modified the code to first try to obtain the `SECRET_KEY` from the environment variable 'SECRET_KEY'. If the environment variable is not set, it will generate a new secret key using `secrets.token_urlsafe(32)` as a fallback. This way, by setting the 'SECRET_KEY' environment variable, we can ensure that all instances of the application use the same secret key, improving the consistency and stability of the replicated setup.

I recommend setting the `SECRET_KEY` environment variable for all instances of the application to avoid potential issues in a multi-instance deployment. This change will enhance the security and robustness of the application, especially in clustered environments. 💪
