### PR TITLE
FIX: Database Directory Perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup -s /bin/sh
 # Copy Python packages and the virtual environment from the builder stage
 COPY --from=builder --chown=appuser:appgroup /app /app
 
+# Create /db directory to prevent permission issues
+RUN mkdir /db && \
+    chown appuser:appgroup /db
+
 # Set the working directory to /app
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@
 
 ### Environment Variables :
 
+#### Required
 You have to define these ENV VARS in order to connect to your KUMA server.
 
-        KUMA_SERVER=<your_kuma_server>
-        KUMA_USERNAME=<your_kuma_username>
-        KUMA_PASSWORD=<your_kuma_password>
-        ADMIN_PASSWORD=<your admin password so you can connect with via the api>
+    KUMA_SERVER: The URL of your Uptime Kuma instance. ex: https://uptime.example.com
+    KUMA_USERNAME: The username of your Uptime Kuma user
+    KUMA_PASSWORD: The password of your Uptime Kuma user
+    ADMIN_PASSWORD: An admin password to access the API
+
+#### Optional
+Additional configuration variables available
+
+    ACCESS_TOKEN_EXPIRATION: Minutes the access token should be valid. Defaults to 8 days.
+    SECRET_KEY: A secret value to encode JWTs with
 
 #### Note:
 
@@ -46,33 +53,34 @@ You can simply create a docker compose file like this :
 ```yaml
 version: "3.9"
 services:
-kuma:
-  container_name: uptime-kuma
-  image: louislam/uptime-kuma:latest
-  ports:
-    - "3001:3001"
-  restart: always
-  volumes:
-    - uptime-kuma:/app/data
+  kuma:
+    container_name: uptime-kuma
+    image: louislam/uptime-kuma:latest
+    ports:
+      - "3001:3001"
+    restart: always
+    volumes:
+      - uptime-kuma:/app/data
 
-api:
-  container_name: backend
-  image: medaziz11/uptimekuma_restapi
-  volumes:
-    - ./db:/db:rwx
-  restart: always
-  environment:
-    - KUMA_SERVER=http://kuma:3001
-    - KUMA_USERNAME=test
-    - KUMA_PASSWORD=123test.
-    - ADMIN_PASSWORD=admin
-  depends_on:
-    - kuma
-  ports:
-    - "8000:8000"
+  api:
+    container_name: backend
+    image: medaziz11/uptimekuma_restapi
+    volumes:
+      - api:/db
+    restart: always
+    environment:
+      - KUMA_SERVER=http://kuma:3001
+      - KUMA_USERNAME=test
+      - KUMA_PASSWORD=123test.
+      - ADMIN_PASSWORD=admin
+    depends_on:
+      - kuma
+    ports:
+      - "8000:8000"
 
 volumes:
-uptime-kuma:
+  uptime-kuma:
+  api:
 ```
 
 ### In order for the example to work: You have to run kuma first then create your kuma username and password then re-run the compose file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     # image: medaziz11/uptimekuma_restapi:1.2
     volumes:
-      - api-db:/db
+      - api:/db
     restart: always
     environment:
       - KUMA_SERVER=${KUMA_SERVER:-http://kuma:3001}
@@ -26,4 +26,4 @@ services:
 
 volumes:
   uptime-kuma:
-  api-db:
+  api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     # image: medaziz11/uptimekuma_restapi:1.2
     volumes:
-      - ./db:/db:rwx
+      - api-db:/db
     restart: always
     environment:
       - KUMA_SERVER=${KUMA_SERVER:-http://kuma:3001}


### PR DESCRIPTION
This small change makes a modification to the Dockerfile to pre-create and set permissions of the `/db` directory. This fully resolves

- Pull request #34
- Issue #33

Support for non-folder volume mounts is a must. We are deploying this image inside a Kubernetes cluster which requires mounts of a PVC, most similar to a Docker Volume. The image in its current state is not compatible with volumes of that sort due to permission issues. In the same way, the current image does not have permissions to create a folder even if just using `docker run` without mounting a volume. This change resolves that.

README.md and docker-compose.yaml have also been updated as part of this change to better reflect compatibility with these volumes.

Also update the README a little bit to add clear-er descriptions of the environment variables, and include optional ENVs in the README as well.