### PR TITLE
[FEATURE] Upgrade Uptime Kuma API version

### DIFF
--- a/app/schemas/monitor.py
+++ b/app/schemas/monitor.py
@@ -8,12 +8,17 @@ from uptime_kuma_api import MonitorType, AuthMethod
 class Monitor(BaseModel):
     type: MonitorType
     name: str
+    description: str
     interval: int = 60
     retryInterval: int = 60
     resendInterval: int = 0
     maxretries: int = 0
     upsideDown: bool = False
     notificationIDList: Optional[List] = None
+
+    # HTTP JSON-QUERY
+    expectedValue: Optional[str] = None
+    jsonPath: Optional[str] = None
 
     # HTTP KEYWORD
     url: Optional[str] = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   kuma:
     container_name: uptime-kuma
-    image: louislam/uptime-kuma:1.19.6
+    image: louislam/uptime-kuma:1.23.2
     ports:
       - "3001:3001"
     restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ sniffio==1.3.0
 starlette==0.20.4
 tortoise-orm==0.19.2
 typing_extensions==4.4.0
-uptime-kuma-api==0.13.0
+uptime-kuma-api==1.2.1
 urllib3==1.26.12
 uvloop==0.17.0
 watchfiles==0.17.0


### PR DESCRIPTION
### **Overview**
This pull request addresses the issue [#58](https://github.com/MedAziz11/Uptime-Kuma-Web-API/issues/58) in the Uptime Kuma Web API repository. The issue detailed problems with creating a monitor of type `json-query`, which was not previously supported.

### **Changes Made**
The following updates have been made in this pull request:

- Added HTTP json-query Fields to Monitor Schema: The json-query type and its relevant fields have been added to the Monitor schema, allowing users to create monitors using this type.

- The uptime-kuma-api dependency has been upgraded to 1.2.1.

- Updated the Uptime Kuma Docker image version to 1.23.2 in the docker-compose.yml file. This update ensures compatibility with the new json-query monitor type.

### **Impact**
These changes enable users to create and utilize the `json-query` monitor type, enhancing the API's functionality and addressing the user-reported issue. It broadens the monitoring capabilities of Uptime Kuma, making the tool more versatile and user-friendly.
