### PR TITLE
Fix token URL in OAuth2PasswordBearer initialization

### DIFF
--- a/app/utils/deps.py
+++ b/app/utils/deps.py
@@ -12,7 +12,7 @@ from models.user import UserCreate, UserResponse
 from config import settings, logger as logging
 from utils import security
 
-oauth2_token = OAuth2PasswordBearer(tokenUrl="/login/access-token/")
+oauth2_token = OAuth2PasswordBearer(tokenUrl="/login/access-token")
 
 
 async def get_current_user(token: str = Depends(oauth2_token)):


### PR DESCRIPTION
Fix token URL in OAuth2PasswordBearer initialization for using app via reverse-proxy like traefik with ssl to exclude error:
`Mixed Content: The page at 'https://domain.com/docs#/' was loaded over HTTPS, but requested an insecure resource 'http://domain.com/login/access-token'. This request has been blocked; the content must be served over HTTPS.`